### PR TITLE
[rush-lint-staged-plugin] Fix exit code 0

### DIFF
--- a/common/changes/rush-lint-staged-plugin/patch-1_2022-06-03-23-52.json
+++ b/common/changes/rush-lint-staged-plugin/patch-1_2022-06-03-23-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-lint-staged-plugin",
+      "comment": "Exit with code 1 if linting failed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-lint-staged-plugin"
+}

--- a/rush-plugins/rush-lint-staged-plugin/README.md
+++ b/rush-plugins/rush-lint-staged-plugin/README.md
@@ -25,18 +25,18 @@ monorepo-root
 |   └── index.js
 ├── apps/my-app
 |   ├── index.js
-|   └── .lintstagedrc.json
+|   └── .lintstagedrc.js
 └── libraries/my-lib
     ├── index.js
-    └── .lintstagedrc.json
+    └── .lintstagedrc.js
 ```
 
 Assuming git staged `apps/my-app/index.js`, `libraries/my-lib/index.js` and `scripts/index.js`
 
 when `rush lint-staged` runs,
 
-1. `apps/my-app/index.js` uses config from `apps/my-app/.lintstagedrc.json`
-2. `libraries/my-lib/index.js` uses config from `libraries/my-lib/.lintstagedrc.json`
+1. `apps/my-app/index.js` uses config from `apps/my-app/.lintstagedrc.js`
+2. `libraries/my-lib/index.js` uses config from `libraries/my-lib/.lintstagedrc.js`
 3. `scripts/index.js` has no related config, nothing runs for this file
 
 # How to plugin into your monorepo
@@ -102,9 +102,9 @@ For example,
 ```
 monorepo-root
 ├── apps/my-app
-|   └── .lintstagedrc.json
+|   └── .lintstagedrc.js
 └── libraries/my-lib
-    └── .lintstagedrc.json
+    └── .lintstagedrc.js
 ```
 
 ALL DONE! try `git add` some files and `git commit`!

--- a/rush-plugins/rush-lint-staged-plugin/src/index.ts
+++ b/rush-plugins/rush-lint-staged-plugin/src/index.ts
@@ -10,7 +10,8 @@ main();
 async function main(): Promise<void> {
   try {
     // https://github.com/okonet/lint-staged/pull/1080
-    await lintStaged();
+    const success = await lintStaged();
+    if (!success) process.exit(1);
   } catch (error: any) {
     if (error.message) {
       // terminal.writeErrorLine(error.message);


### PR DESCRIPTION
### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

**Does this PR introduce a breaking change?** (check one)

- [x] Yes?
- [ ] No

If yes, please describe the impact and migration path for existing applications:

### Summary
The current implementation always return exit code `0`, so the git hooks never fail, which is probably not intentional.

According to https://github.com/okonet/lint-staged#can-i-use-lint-staged-via-node, the programmatic usage of `lint-staged` returns a boolean instead of throwing on failure.

This PR exits with `1` if that boolean is `false`.

I'm also taking the liberty to update Readme to use `.js` config instead of `.json` as example, since that would be the "riggable" one.