### PR TITLE
Sort package is safe

### DIFF
--- a/common/changes/rush-sort-package-json/sort-package-is-safe_2022-06-04-00-35.json
+++ b/common/changes/rush-sort-package-json/sort-package-is-safe_2022-06-04-00-35.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-sort-package-json",
+      "comment": "Mark as safe for simultaneous processes",
+      "type": "patch"
+    }
+  ],
+  "packageName": "rush-sort-package-json"
+}

--- a/rush-plugins/rush-sort-package-json/command-line.json
+++ b/rush-plugins/rush-sort-package-json/command-line.json
@@ -5,7 +5,8 @@
       "name": "sort-package-json",
       "commandKind": "global",
       "summary": "Rush plugin for sort package.json file in the project",
-      "shellCommand": "node <packageFolder>/lib/index.js"
+      "shellCommand": "node <packageFolder>/lib/index.js",
+      "safeForSimultaneousRushProcesses": true
     }
   ]
 }


### PR DESCRIPTION
I'd like to run it in `postRushInstall`, and it needs to be marked as safe for that. Hopefully it is safe indeed?