### PR TITLE
feat(rush-init-project): Add CLI parameters -a, --answer to accept answers from external JSON

### DIFF
--- a/common/changes/rush-init-project-plugin/feat-rush-init_2022-08-24-03-02.json
+++ b/common/changes/rush-init-project-plugin/feat-rush-init_2022-08-24-03-02.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-init-project-plugin",
+      "comment": "Add CLI parameters -a, --answer to accept answers from external JSON",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-init-project-plugin"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -55,6 +55,7 @@ importers:
       '@rushstack/rush-sdk': 5.62.4
       '@types/heft-jest': 1.0.1
       '@types/inquirer': ~8.1.3
+      '@types/lodash': 4.14.184
       '@types/node': 12.20.24
       chalk: 4.1.2
       commander: ~9.4.0
@@ -63,6 +64,7 @@ importers:
       inquirer: ~8.2.0
       inquirer-autocomplete-prompt: ~1.4.0
       lilconfig: ~2.0.4
+      lodash: 4.17.21
       node-plop: 0.26.3
       ora: 5.4.1
       sort-package-json: 1.54.0
@@ -79,6 +81,7 @@ importers:
       inquirer: 8.2.0
       inquirer-autocomplete-prompt: 1.4.0_inquirer@8.2.0
       lilconfig: 2.0.4
+      lodash: 4.17.21
       node-plop: 0.26.3
       ora: 5.4.1
       sort-package-json: 1.54.0
@@ -91,6 +94,7 @@ importers:
       '@rushstack/heft-node-rig': 1.2.31_@rushstack+heft@0.42.3
       '@types/heft-jest': 1.0.1
       '@types/inquirer': 8.1.3
+      '@types/lodash': 4.14.184
       '@types/node': 12.20.24
       eslint: 7.32.0
       typescript: 4.4.2
@@ -1324,6 +1328,10 @@ packages:
 
   /@types/json-schema/7.0.9:
     resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==}
+    dev: true
+
+  /@types/lodash/4.14.184:
+    resolution: {integrity: sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==}
     dev: true
 
   /@types/minimatch/3.0.5:

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -57,6 +57,7 @@ importers:
       '@types/inquirer': ~8.1.3
       '@types/node': 12.20.24
       chalk: 4.1.2
+      commander: ~9.4.0
       eslint: 7.32.0
       handlebars-helpers: ~0.10.0
       inquirer: ~8.2.0
@@ -73,6 +74,7 @@ importers:
       '@rushstack/node-core-library': 3.44.1
       '@rushstack/rush-sdk': 5.62.4
       chalk: 4.1.2
+      commander: 9.4.0
       handlebars-helpers: 0.10.0
       inquirer: 8.2.0
       inquirer-autocomplete-prompt: 1.4.0_inquirer@8.2.0
@@ -2501,6 +2503,11 @@ packages:
   /commander/8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
+    dev: false
+
+  /commander/9.4.0:
+    resolution: {integrity: sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==}
+    engines: {node: ^12.20.0 || >=14}
     dev: false
 
   /component-emitter/1.3.0:

--- a/rush-plugins/rush-init-project-plugin/.gitignore
+++ b/rush-plugins/rush-init-project-plugin/.gitignore
@@ -1,1 +1,2 @@
 lib/
+temp/

--- a/rush-plugins/rush-init-project-plugin/command-line.json
+++ b/rush-plugins/rush-init-project-plugin/command-line.json
@@ -8,6 +8,32 @@
       "shellCommand": "rush-init-project",
       "safeForSimultaneousRushProcesses": true
     }
+  ],
+  "parameters": [
+    {
+      "parameterKind": "string",
+      "description": "Provide node-plop answers with JSON string",
+      "shortName": "-a",
+      "longName": "--answer",
+      "argumentName": "ANSWER",
+      "associatedCommands": ["init-project"],
+      "required": false
+    },
+    {
+      "parameterKind": "flag",
+      "description": "Provide the option isDryRun in plugin context",
+      "shortName": "-d",
+      "longName": "--dry-run",
+      "associatedCommands": ["init-project"],
+      "required": false
+    },
+    {
+      "parameterKind": "flag",
+      "description": "Provide node-plop answers with JSON string",
+      "shortName": "-v",
+      "longName": "--verbose",
+      "associatedCommands": ["init-project"],
+      "required": false
+    }
   ]
-  // "parameters": [],
 }

--- a/rush-plugins/rush-init-project-plugin/command-line.json
+++ b/rush-plugins/rush-init-project-plugin/command-line.json
@@ -12,7 +12,7 @@
   "parameters": [
     {
       "parameterKind": "string",
-      "description": "Provide node-plop answers with JSON string",
+      "description": "Provide predefined answers with JSON string",
       "shortName": "-a",
       "longName": "--answer",
       "argumentName": "ANSWER",
@@ -29,7 +29,7 @@
     },
     {
       "parameterKind": "flag",
-      "description": "Provide node-plop answers with JSON string",
+      "description": "Provide verbose log output",
       "shortName": "-v",
       "longName": "--verbose",
       "associatedCommands": ["init-project"],

--- a/rush-plugins/rush-init-project-plugin/package.json
+++ b/rush-plugins/rush-init-project-plugin/package.json
@@ -37,6 +37,7 @@
     "inquirer": "~8.2.0",
     "inquirer-autocomplete-prompt": "~1.4.0",
     "lilconfig": "~2.0.4",
+    "lodash": "4.17.21",
     "node-plop": "0.26.3",
     "ora": "5.4.1",
     "sort-package-json": "1.54.0",
@@ -50,6 +51,7 @@
     "@rushstack/heft-node-rig": "1.2.31",
     "@types/heft-jest": "1.0.1",
     "@types/inquirer": "~8.1.3",
+    "@types/lodash": "4.14.184",
     "@types/node": "12.20.24",
     "eslint": "7.32.0",
     "typescript": "4.4.2"

--- a/rush-plugins/rush-init-project-plugin/package.json
+++ b/rush-plugins/rush-init-project-plugin/package.json
@@ -32,6 +32,7 @@
     "@rushstack/node-core-library": "3.44.1",
     "@rushstack/rush-sdk": "5.62.4",
     "chalk": "4.1.2",
+    "commander": "~9.4.0",
     "handlebars-helpers": "~0.10.0",
     "inquirer": "~8.2.0",
     "inquirer-autocomplete-prompt": "~1.4.0",

--- a/rush-plugins/rush-init-project-plugin/src/cli.ts
+++ b/rush-plugins/rush-init-project-plugin/src/cli.ts
@@ -10,7 +10,7 @@ import { TerminalSingleton } from "./terminal";
   program
     .option(
       "-a, --answer <ANSWER>",
-      "Provide node-plop answers with JSON string"
+      "Provide predefined answers with JSON string"
     )
     .option(
       "-d, --dry-run",
@@ -24,7 +24,8 @@ import { TerminalSingleton } from "./terminal";
     )
     .description("Initialize new Rush projects")
     .action(async (params) => {
-      const terminal: Terminal = TerminalSingleton.getInstance(params?.verbose);
+      TerminalSingleton.setVerboseEnabled(params?.verbose);
+      const terminal: Terminal = TerminalSingleton.getInstance();
       try {
         getTemplatesFolderAndValidate();
         await initProject(params);

--- a/rush-plugins/rush-init-project-plugin/src/cli.ts
+++ b/rush-plugins/rush-init-project-plugin/src/cli.ts
@@ -24,7 +24,8 @@ import { TerminalSingleton } from "./terminal";
     )
     .description("Initialize new Rush projects")
     .action(async (params) => {
-      TerminalSingleton.setVerboseEnabled(params?.verbose);
+      if (typeof params?.verbose === "boolean")
+        TerminalSingleton.setVerboseEnabled(params?.verbose);
       const terminal: Terminal = TerminalSingleton.getInstance();
       try {
         getTemplatesFolderAndValidate();

--- a/rush-plugins/rush-init-project-plugin/src/cli.ts
+++ b/rush-plugins/rush-init-project-plugin/src/cli.ts
@@ -1,23 +1,47 @@
 #!/usr/bin/env node
 
+import { Terminal } from "@rushstack/node-core-library";
+import { program } from "commander";
 import { initProject } from "./init-project";
 import { getTemplatesFolderAndValidate } from "./logic/templateFolder";
-import { terminal } from "./terminal";
+import { TerminalSingleton } from "./terminal";
 
-// eslint-disable-next-line @typescript-eslint/no-floating-promises
-main();
+(async () => {
+  program
+    .option(
+      "-a, --answer <ANSWER>",
+      "Provide node-plop answers with JSON string"
+    )
+    .option(
+      "-d, --dry-run",
+      "Provide the option isDryRun in plugin context",
+      false
+    )
+    .option(
+      "-v, --verbose",
+      "Enable output verbose debug purposing messages",
+      false
+    )
+    .description("Initialize new Rush projects")
+    .action(async (params) => {
+      const terminal: Terminal = TerminalSingleton.getInstance(params?.verbose);
+      try {
+        getTemplatesFolderAndValidate();
+        await initProject(params);
+      } catch (error: any) {
+        if (error.message) {
+          terminal.writeErrorLine(error.message);
+        } else {
+          throw error;
+        }
+        process.exit(1);
+      }
+    });
 
-async function main(): Promise<void> {
-  try {
-    getTemplatesFolderAndValidate();
-    await initProject();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  } catch (error: any) {
-    if (error.message) {
-      terminal.writeErrorLine(error.message);
-    } else {
-      throw error;
-    }
+  program.on("command:*", () => {
+    console.error("undefined command", program.args.join(" "));
     process.exit(1);
-  }
-}
+  });
+
+  await program.parseAsync(process.argv);
+})().catch((e) => (e?.message ? console.error(e.message) : console.error(e)));

--- a/rush-plugins/rush-init-project-plugin/src/cli.ts
+++ b/rush-plugins/rush-init-project-plugin/src/cli.ts
@@ -24,8 +24,7 @@ import { TerminalSingleton } from "./terminal";
     )
     .description("Initialize new Rush projects")
     .action(async (params) => {
-      if (typeof params?.verbose === "boolean")
-        TerminalSingleton.setVerboseEnabled(params?.verbose);
+      TerminalSingleton.setVerboseEnabled(params?.verbose ?? false);
       const terminal: Terminal = TerminalSingleton.getInstance();
       try {
         getTemplatesFolderAndValidate();

--- a/rush-plugins/rush-init-project-plugin/src/index.ts
+++ b/rush-plugins/rush-init-project-plugin/src/index.ts
@@ -7,3 +7,4 @@ export type {
 export type { IHooks, IActionsHookParams, IPromptsHookParams } from "./hooks";
 export type { NodePlopAPI, PromptQuestion } from "node-plop";
 export type { IExtendedAnswers as IAnswers } from "./plopfile";
+export * from "./terminal";

--- a/rush-plugins/rush-init-project-plugin/src/init-project.ts
+++ b/rush-plugins/rush-init-project-plugin/src/init-project.ts
@@ -8,7 +8,7 @@ import * as path from "path";
 import { TerminalSingleton } from "./terminal";
 
 export interface ICliParams {
-  answer?: string | object;
+  answer?: string | Record<string, string>;
   verbose: boolean;
   dryRun: boolean;
 }

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -42,15 +42,12 @@ export interface IConfig {
 }
 
 export interface IPlugin {
-  apply: (
-    hook: IHooks,
-    pluginContext: Pick<IPluginContext, keyof IPluginContext>
-  ) => void;
+  apply: (hook: IHooks, pluginContext: IPluginContext) => void;
 }
 
 export interface IPluginContext extends Record<string, any> {
   isDryRun: boolean;
-  noInteraction: boolean;
+  externalAnswer: boolean;
 }
 
 export class TemplateConfiguration {

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -47,7 +47,7 @@ export interface IPlugin {
 
 export interface IPluginContext extends Record<string, any> {
   isDryRun: boolean;
-  externalAnswer: Record<string, string>;
+  cliAnswer: Record<string, string>;
 }
 
 export class TemplateConfiguration {

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -42,11 +42,15 @@ export interface IConfig {
 }
 
 export interface IPlugin {
-  apply: (hook: IHooks, pluginContext: IPluginContext) => void;
+  apply: (
+    hook: IHooks,
+    pluginContext: Pick<IPluginContext, keyof IPluginContext>
+  ) => void;
 }
 
 export interface IPluginContext extends Record<string, any> {
   isDryRun: boolean;
+  noInteraction: boolean;
 }
 
 export class TemplateConfiguration {

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -47,7 +47,7 @@ export interface IPlugin {
 
 export interface IPluginContext extends Record<string, any> {
   isDryRun: boolean;
-  externalAnswer: boolean;
+  externalAnswer: Record<string, string>;
 }
 
 export class TemplateConfiguration {

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -8,6 +8,7 @@ import type {
   ActionType,
   DynamicPromptsFunction,
   NodePlopAPI,
+  PlopCfg,
   PromptQuestion,
 } from "node-plop";
 import * as path from "path";
@@ -27,6 +28,7 @@ import {
   getTemplateNameList,
   getTemplatesFolder,
 } from "./logic/templateFolder";
+import type { ICliParams } from "./init-project";
 
 export interface IExtendedAnswers extends Answers {
   authorName: string;
@@ -38,18 +40,17 @@ export interface IExtendedAnswers extends Answers {
   shouldRunRushUpdate: boolean;
 }
 
-export default function (plop: NodePlopAPI): void {
+export default function (
+  plop: NodePlopAPI,
+  plopCfg: PlopCfg & ICliParams
+): void {
   const rushConfiguration: RushConfiguration = loadRushConfiguration();
   const monorepoRoot: string = rushConfiguration.rushJsonFolder;
-  const isDryRun: boolean =
-    process.argv.includes("--dry-run") || Boolean(process.env.DRY_RUN);
-  const noInteraction: boolean =
-    process.argv.includes("--config") || Boolean(process.env.NO_INTERACTION);
 
   const hooks: IHooks = initHooks();
   const pluginContext: IPluginContext = {
-    isDryRun,
-    noInteraction,
+    isDryRun: plopCfg.dryRun || Boolean(process.env.DRY_RUN),
+    externalAnswer: Boolean(plopCfg.answer),
   };
 
   registerActions(plop);
@@ -209,7 +210,7 @@ export default function (plop: NodePlopAPI): void {
         .join(templatesFolder, template)
         .replace(/\\/g, "/");
 
-      const actions: ActionType[] = isDryRun
+      const actions: ActionType[] = plopCfg.dryRun
         ? []
         : [
             {

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -51,7 +51,7 @@ export default function (
   const hooks: IHooks = initHooks();
   const pluginContext: IPluginContext = {
     isDryRun: plopCfg.dryRun || Boolean(process.env.DRY_RUN),
-    externalAnswer: typeof plopCfg.answer === "object" ? plopCfg.answer : {},
+    cliAnswer: typeof plopCfg.answer === "object" ? plopCfg.answer : {},
   };
 
   registerActions(plop);
@@ -135,10 +135,10 @@ export default function (
   ];
 
   let templateConfiguration: TemplateConfiguration | undefined;
-  const loadTemplateConfiguration = async (
+  const loadTemplateConfiguration: (
     promptQueue: PromptQuestion[],
     template: string
-  ): Promise<void> => {
+  ) => Promise<void> = async (promptQueue, template) => {
     templateConfiguration = await TemplateConfiguration.loadFromTemplate(
       template
     );
@@ -163,19 +163,19 @@ export default function (
     let promptQueue: PromptQuestion[] = defaultPrompts.slice();
     let allAnswers: Partial<IExtendedAnswers> = {};
 
-    if (pluginContext.externalAnswer) {
+    if (pluginContext.cliAnswer) {
       // if some answers are provided externally, use them instead of prompting.
       // if template is provided externally, load template configuration.
-      if (pluginContext.externalAnswer?.template) {
+      if (pluginContext.cliAnswer?.template) {
         await loadTemplateConfiguration(
           promptQueue,
-          pluginContext.externalAnswer.template
+          pluginContext.cliAnswer.template
         );
       }
       const promptQueueNames: Array<string | undefined> = promptQueue.map(
         (x) => x.name
       );
-      allAnswers = pickBy(pluginContext.externalAnswer, (v, k) =>
+      allAnswers = pickBy(pluginContext.cliAnswer, (v, k) =>
         promptQueueNames.includes(k)
       );
       // filter out prompts that are provided externally.

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -29,6 +29,8 @@ import {
 } from "./logic/templateFolder";
 
 export interface IExtendedAnswers extends Answers {
+  authorName: string;
+  description: string;
   template: string;
   packageName: string;
   unscopedPackageName: string;
@@ -41,10 +43,13 @@ export default function (plop: NodePlopAPI): void {
   const monorepoRoot: string = rushConfiguration.rushJsonFolder;
   const isDryRun: boolean =
     process.argv.includes("--dry-run") || Boolean(process.env.DRY_RUN);
+  const noInteraction: boolean =
+    process.argv.includes("--config") || Boolean(process.env.NO_INTERACTION);
 
   const hooks: IHooks = initHooks();
   const pluginContext: IPluginContext = {
     isDryRun,
+    noInteraction,
   };
 
   registerActions(plop);

--- a/rush-plugins/rush-init-project-plugin/src/terminal.ts
+++ b/rush-plugins/rush-init-project-plugin/src/terminal.ts
@@ -7,28 +7,20 @@ import {
 
 export class TerminalSingleton {
   private static _instance: Terminal | undefined;
-  private static _verboseEnabled: boolean = false;
-  private constructor() {}
+  private static _terminalProvider: ConsoleTerminalProvider;
+  private constructor() {
+    TerminalSingleton._terminalProvider = new ConsoleTerminalProvider();
+  }
   public static getInstance(): Terminal {
     if (!TerminalSingleton._instance) {
       TerminalSingleton._instance = new Terminal(
-        new ConsoleTerminalProvider({
-          verboseEnabled: TerminalSingleton._verboseEnabled,
-        })
+        TerminalSingleton._terminalProvider
       );
     }
     return TerminalSingleton._instance;
   }
-  public static setVerboseEnabled(enabled?: boolean): void {
-    if (enabled === undefined) {
-      return;
-    }
-    TerminalSingleton._verboseEnabled = enabled;
-    TerminalSingleton._instance = new Terminal(
-      new ConsoleTerminalProvider({
-        verboseEnabled: TerminalSingleton._verboseEnabled,
-      })
-    );
+  public static setVerboseEnabled(enabled: boolean): void {
+    TerminalSingleton._terminalProvider.verboseEnabled = enabled;
   }
 }
 
@@ -47,7 +39,9 @@ export interface ILogger {
 
 export function createLog(logOption: ILogOption): ILogger {
   const { prefix, verboseEnabled } = logOption;
-  TerminalSingleton.setVerboseEnabled(verboseEnabled);
+  // eslint-disable-next-line no-unused-expressions
+  if (typeof verboseEnabled === "boolean")
+    TerminalSingleton.setVerboseEnabled(verboseEnabled);
   const terminal: Terminal = TerminalSingleton.getInstance();
   return {
     info(msg: string) {

--- a/rush-plugins/rush-init-project-plugin/src/terminal.ts
+++ b/rush-plugins/rush-init-project-plugin/src/terminal.ts
@@ -1,6 +1,82 @@
 import {
-  Terminal,
+  ColorValue,
   ConsoleTerminalProvider,
+  Terminal,
+  TextAttribute,
 } from "@rushstack/node-core-library";
 
-export const terminal: Terminal = new Terminal(new ConsoleTerminalProvider());
+const verboseEnabled: boolean = process.argv.includes("--verbose");
+
+export const terminal: Terminal = new Terminal(
+  new ConsoleTerminalProvider({
+    verboseEnabled,
+  })
+);
+
+export interface LogOption {
+  prefix: string;
+}
+
+export type Logger = {
+  info(msg: string): void;
+  warn(msg: string): void;
+  error(msg: string): void;
+  success(msg: string): void;
+  verbose(msg: string): void;
+};
+
+export function createLog(logOption: LogOption): Logger {
+  const { prefix } = logOption;
+  return {
+    info(msg: string) {
+      terminal.write({
+        text: `${prefix} `,
+        backgroundColor: ColorValue.Blue,
+        foregroundColor: ColorValue.Black,
+      });
+      terminal.writeLine({
+        text: msg,
+        textAttributes: [TextAttribute.Dim],
+      });
+    },
+    warn(msg: string) {
+      terminal.write({
+        text: `${prefix} `,
+        backgroundColor: ColorValue.Yellow,
+        foregroundColor: ColorValue.Black,
+      });
+      terminal.writeLine({
+        text: msg,
+        foregroundColor: ColorValue.Yellow,
+      });
+    },
+    error(msg: string) {
+      terminal.write({
+        text: `${prefix} `,
+        foregroundColor: ColorValue.White,
+        backgroundColor: ColorValue.Red,
+      });
+      terminal.writeLine({
+        text: msg,
+        foregroundColor: ColorValue.Red,
+      });
+    },
+    success(msg: string) {
+      terminal.write({
+        text: `${prefix} `,
+        foregroundColor: ColorValue.Black,
+        backgroundColor: ColorValue.Green,
+      });
+      terminal.writeLine({
+        text: msg,
+        foregroundColor: ColorValue.Green,
+      });
+    },
+    verbose(msg: string) {
+      terminal.writeVerboseLine({
+        text: `${prefix} ${msg}`,
+        textAttributes: [TextAttribute.Dim],
+      });
+    },
+  };
+}

--- a/rush-plugins/rush-init-project-plugin/src/terminal.ts
+++ b/rush-plugins/rush-init-project-plugin/src/terminal.ts
@@ -7,16 +7,28 @@ import {
 
 export class TerminalSingleton {
   private static _instance: Terminal | undefined;
+  private static _verboseEnabled: boolean = false;
   private constructor() {}
-  public static getInstance(verboseEnabled?: boolean): Terminal {
+  public static getInstance(): Terminal {
     if (!TerminalSingleton._instance) {
       TerminalSingleton._instance = new Terminal(
         new ConsoleTerminalProvider({
-          verboseEnabled,
+          verboseEnabled: TerminalSingleton._verboseEnabled,
         })
       );
     }
     return TerminalSingleton._instance;
+  }
+  public static setVerboseEnabled(enabled?: boolean): void {
+    if (enabled === undefined) {
+      return;
+    }
+    TerminalSingleton._verboseEnabled = enabled;
+    TerminalSingleton._instance = new Terminal(
+      new ConsoleTerminalProvider({
+        verboseEnabled: TerminalSingleton._verboseEnabled,
+      })
+    );
   }
 }
 
@@ -35,7 +47,8 @@ export interface ILogger {
 
 export function createLog(logOption: ILogOption): ILogger {
   const { prefix, verboseEnabled } = logOption;
-  const terminal: Terminal = TerminalSingleton.getInstance(verboseEnabled);
+  TerminalSingleton.setVerboseEnabled(verboseEnabled);
+  const terminal: Terminal = TerminalSingleton.getInstance();
   return {
     info(msg: string) {
       terminal.write({

--- a/rush-plugins/rush-init-project-plugin/src/terminal.ts
+++ b/rush-plugins/rush-init-project-plugin/src/terminal.ts
@@ -5,28 +5,37 @@ import {
   TextAttribute,
 } from "@rushstack/node-core-library";
 
-const verboseEnabled: boolean = process.argv.includes("--verbose");
-
-export const terminal: Terminal = new Terminal(
-  new ConsoleTerminalProvider({
-    verboseEnabled,
-  })
-);
-
-export interface LogOption {
-  prefix: string;
+export class TerminalSingleton {
+  private static _instance: Terminal | undefined;
+  private constructor() {}
+  public static getInstance(verboseEnabled?: boolean): Terminal {
+    if (!TerminalSingleton._instance) {
+      TerminalSingleton._instance = new Terminal(
+        new ConsoleTerminalProvider({
+          verboseEnabled,
+        })
+      );
+    }
+    return TerminalSingleton._instance;
+  }
 }
 
-export type Logger = {
+export interface ILogOption {
+  prefix: string;
+  verboseEnabled?: boolean;
+}
+
+export interface ILogger {
   info(msg: string): void;
   warn(msg: string): void;
   error(msg: string): void;
   success(msg: string): void;
   verbose(msg: string): void;
-};
+}
 
-export function createLog(logOption: LogOption): Logger {
-  const { prefix } = logOption;
+export function createLog(logOption: ILogOption): ILogger {
+  const { prefix, verboseEnabled } = logOption;
+  const terminal: Terminal = TerminalSingleton.getInstance(verboseEnabled);
   return {
     info(msg: string) {
       terminal.write({

--- a/rush-plugins/rush-init-project-plugin/src/terminal.ts
+++ b/rush-plugins/rush-init-project-plugin/src/terminal.ts
@@ -7,10 +7,9 @@ import {
 
 export class TerminalSingleton {
   private static _instance: Terminal | undefined;
-  private static _terminalProvider: ConsoleTerminalProvider;
-  private constructor() {
-    TerminalSingleton._terminalProvider = new ConsoleTerminalProvider();
-  }
+  private static _terminalProvider: ConsoleTerminalProvider =
+    new ConsoleTerminalProvider();
+  private constructor() {}
   public static getInstance(): Terminal {
     if (!TerminalSingleton._instance) {
       TerminalSingleton._instance = new Terminal(


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [x] Reason for adding this feature

Support running rush-init-project-plugin in non-interactive environments by providing answers to the CLI in a JSON string parameter.

- [x] How to use

Use the -a / --answer to provide answers to rush-init-project-plugin in non-interactive environments.
Answers should be provided as a JSON string with keys corresponding to the `PromptQuestion.name`.
Questions that are provided in the CLI answers will not be prompted interactively.
Plugins have the awareness of the CLI answers in `pluginContext.cliAnswer`.

- [x] A basic example

```bash
rush init-project -a '{"template": "webpack5-web", authorName: "John Doe"}'
# or
rush init-project --answer '{"template": "webpack5-web", authorName: "John Doe"}'
```

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

### Detail

### How to test it
