### PR TITLE
Feat init project rush config

### DIFF
--- a/common/changes/rush-init-project-plugin/feat-init-project-rush-config_2022-08-30-17-42.json
+++ b/common/changes/rush-init-project-plugin/feat-init-project-rush-config_2022-08-30-17-42.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-init-project-plugin",
+      "comment": "Adds \"decoupledLocalDependencies\" and \"tags\" to the fields of the default rush project configuration",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-init-project-plugin"
+}

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -26,19 +26,27 @@ const loaders: Record<string, (path: string) => IConfig> = {
   },
 };
 
+/**
+ * See https://rushjs.io/pages/configs/rush_json/
+ */
 export interface IDefaultProjectConfiguration {
   reviewCategory?: string;
+  /**
+   * @deprecated Use `decoupledLocalDependencies` instead.
+   */
   cyclicDependencyProjects?: string[];
+  decoupledLocalDependencies?: string[];
   shouldPublish?: boolean;
   skipRushCheck?: boolean;
   versionPolicyName?: string;
   publishFolder?: string;
+  tags?: string[];
 }
 
 export interface IConfig {
   prompts?: PromptQuestion[];
   plugins?: IPlugin[];
-  defaultProjectConfiguration: IDefaultProjectConfiguration;
+  defaultProjectConfiguration?: IDefaultProjectConfiguration;
 }
 
 export interface IPlugin {


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [ ] Reason for adding this feature
- [ ] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Adds `decoupledLocalDependencies` and `tags` as the fields of default rush project configuration

### Detail

### How to test it
