### PR TITLE
feat(init-project): add displayName to init config file

### DIFF
--- a/common/_templates/rush-plugin-for-command/init.config.ts
+++ b/common/_templates/rush-plugin-for-command/init.config.ts
@@ -1,17 +1,29 @@
-import type { IConfig, IHooks, IAnswers, PromptQuestion } from "../../autoinstallers/command-plugins/node_modules/rush-init-project-plugin";
+import type {
+  IConfig,
+  IHooks,
+  IAnswers,
+  PromptQuestion,
+} from "../../autoinstallers/command-plugins/node_modules/rush-init-project-plugin";
 
 const config: IConfig = {
   prompts: [],
   plugins: [
     {
       apply: (hooks: IHooks) => {
-        hooks.promptQuestion.for("projectFolder").tap("command-plugin", (promptQuestion: PromptQuestion, answersSoFar: IAnswers) => {
-          const { unscopedPackageName } = answersSoFar;
-          promptQuestion.default = `rush-plugins/${unscopedPackageName}`
-        });
+        hooks.promptQuestion
+          .for("projectFolder")
+          .tap(
+            "command-plugin",
+            (promptQuestion: PromptQuestion, answersSoFar: IAnswers) => {
+              const { unscopedPackageName } = answersSoFar;
+              promptQuestion.default = `rush-plugins/${unscopedPackageName}`;
+            }
+          );
       },
     },
   ],
+  defaultProjectConfiguration: {},
+  // displayName: "Rush Plugin For Command",
 };
 
 export default config;

--- a/common/changes/rush-init-project-plugin/feat-rush-init_2022-11-28-02-27.json
+++ b/common/changes/rush-init-project-plugin/feat-rush-init_2022-11-28-02-27.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "rush-init-project-plugin",
+      "comment": "Support displayName to IConfig in init config file for rush-init-project-plugin",
+      "type": "minor"
+    }
+  ],
+  "packageName": "rush-init-project-plugin"
+}

--- a/rush-plugins/rush-init-project-plugin/src/cli.ts
+++ b/rush-plugins/rush-init-project-plugin/src/cli.ts
@@ -27,7 +27,7 @@ import { TerminalSingleton } from "./terminal";
       TerminalSingleton.setVerboseEnabled(params?.verbose ?? false);
       const terminal: Terminal = TerminalSingleton.getInstance();
       try {
-        getTemplatesFolderAndValidate();
+        await getTemplatesFolderAndValidate();
         await initProject(params);
       } catch (error: any) {
         if (error.message) {

--- a/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
+++ b/rush-plugins/rush-init-project-plugin/src/logic/TemplateConfiguration.ts
@@ -47,6 +47,7 @@ export interface IConfig {
   prompts?: PromptQuestion[];
   plugins?: IPlugin[];
   defaultProjectConfiguration?: IDefaultProjectConfiguration;
+  displayName?: string;
 }
 
 export interface IPlugin {
@@ -62,6 +63,7 @@ export class TemplateConfiguration {
   private _prompts: PromptQuestion[];
   private _plugins: IPlugin[];
   private _defaultProjectConfiguration: IDefaultProjectConfiguration;
+  public displayName: string;
 
   private constructor(template: string) {
     const templateFolder: string = getTemplateFolder(template);
@@ -72,6 +74,7 @@ export class TemplateConfiguration {
     this._prompts = [];
     this._plugins = [];
     this._defaultProjectConfiguration = {};
+    this.displayName = "";
     if (result && result.config) {
       if (result.config.prompts) {
         this._prompts = result.config.prompts;
@@ -82,6 +85,9 @@ export class TemplateConfiguration {
       if (result.config.defaultProjectConfiguration) {
         this._defaultProjectConfiguration =
           result.config.defaultProjectConfiguration;
+      }
+      if (result.config.displayName) {
+        this.displayName = result.config.displayName;
       }
     }
   }

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -150,9 +150,7 @@ export default function (
     );
     const templateChoices: { name: string; value: string }[] =
       templateNameList.map((x) => ({
-        name: x.displayName
-          ? `${x.displayName} (${x.folderName})`
-          : x.folderName,
+        name: x.displayName ? x.displayName : x.folderName,
         value: x.folderName,
       }));
     defaultPrompts.unshift({

--- a/rush-plugins/rush-init-project-plugin/src/plopfile.ts
+++ b/rush-plugins/rush-init-project-plugin/src/plopfile.ts
@@ -161,7 +161,9 @@ export default function (
         if (!input) {
           return templateChoices;
         }
-        return templateChoices.filter((x) => x.name.includes(input));
+        return templateChoices.filter(
+          (x) => x.name.includes(input) || x.value.includes(input)
+        );
       },
       loop: false,
       pageSize: 20,


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### Basic Checks

Have you run `rush change` for this change?

- [x] Yes
- [ ] No

If **No**, please run `rush change` before, this is necessary.

If adding a **new feature**, the PR's description includes:

- [x] Reason for adding this feature
- [x] How to use
- [ ] A basic example

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

### Summary

Support displayName to IConfig in init config file for rush-init-project-plugin.

### Detail

Show displayName during selecting templates

<img width="545" alt="init_withDisplayName" src="https://user-images.githubusercontent.com/4646856/204178924-d6221606-ac3d-4d1b-ad2c-480b6bef4ee1.png">

Backward compatibility without displayName

<img width="481" alt="init_withoutDisplayName" src="https://user-images.githubusercontent.com/4646856/204178946-4065c8f6-84d5-4f4b-9b6f-4404ab54206b.png">

### How to test it
